### PR TITLE
Fix indentation errors to indent size 4

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,6 @@
 
 root = true
 
-
 [*]
 end_of_line = lf
 charset = utf-8

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# EditorConfig helps define and maintain consistent
+# indentation.
+
+root = true
+
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+
+[*.txt]
+indent_style = tab
+indent_size = 4
+
+[*.{diff,md}]
+trim_trailing_whitespace = false


### PR DESCRIPTION
EditorConfig helps to define and maintain consistent indentation. For this app indent size 4 is chosen for comfortable readability.